### PR TITLE
feat: tidy exceptions, and priorise exceptions from Python code

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,14 @@ with iterable_subprocess(['cat'], iterable_of_bytes) as output:
 
 ## Exceptions
 
-If the process exits with a non-zero error code, a `subprocess.SubprocessError` exception will be raised, with the contents of the process's standard error as the message. Only the most recent 65536 bytes of the process's standard error are returned by default.
+Python's `subprocess.Popen` is used to start the process, and any exceptions it raises are propagated without transformation. For example, if the subprocess can't be found, then a `FileNotFoundError` is raised.
 
-Other exceptions can be output by the context, for example if code inside the context itself raises an exception then this exception is propagated through the context. However even in this case, if the return code of the process is non-zero, the corresponding `subprocess.SubprocessError` is the one that propagates out of the context.
+If the process starts, but exits with a non-zero return code, then an `iterable_subprocess.IterableSubprocessError` exception will be raised with two members:
+
+- `returncode` - the return code of the process
+- `stderr` - the final 65536 bytes of the standard error of the process
+
+However, if the process starts, but an exception is raised from inside the context, then this exception is propagated, even if the process subsequently exits with a non-zero return code.
 
 
 ## Example: unzip the first file of a ZIP archive while downloading

--- a/iterable_subprocess.py
+++ b/iterable_subprocess.py
@@ -71,24 +71,28 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
             if total_length - len(stderr_deque[0]) >= chunk_size:
                 stderr_deque.popleft()
 
-    proc = None
     exiting = False
     stderr_deque = deque()
 
-    try:
-        with \
-                Popen(program, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc, \
-                thread(input_to, proc.stdin, lambda: exiting), \
-                thread(keep_only_most_recent, proc.stderr, stderr_deque):
+    with \
+            Popen(program, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc, \
+            thread(input_to, proc.stdin, lambda: exiting), \
+            thread(keep_only_most_recent, proc.stderr, stderr_deque):
 
-            output = output_from(proc.stdout)
+        output = output_from(proc.stdout)
 
-            try:
-                yield output
-            finally:
-                exiting = True
-                for _ in output:  # Avoid a deadlock if the thread is still writing
-                    pass
-    finally:
-        if proc is not None and proc.returncode:
-            raise SubprocessError(b''.join(stderr_deque)[-chunk_size:], proc.returncode)
+        try:
+            yield output
+        finally:
+            exiting = True
+            for _ in output:  # Avoid a deadlock if the thread is still writing
+                pass
+
+    if proc.returncode:
+        raise IterableSubprocessError(proc.returncode, b''.join(stderr_deque)[-chunk_size:])
+
+
+class IterableSubprocessError(SubprocessError):
+    def __init__(self, returncode, stderr):
+        self.returncode = returncode
+        self.stderr = stderr


### PR DESCRIPTION
Prioritising Python-raised exceptions, since they probably happened first. And going back to a custom exception so it's a bit more friendly to being caught