### PR TITLE
refactor: group output thread/processes

### DIFF
--- a/iterable_subprocess.py
+++ b/iterable_subprocess.py
@@ -6,22 +6,34 @@ from threading import Thread
 
 @contextmanager
 def iterable_subprocess(program, input_chunks, chunk_size=65536):
-    # This context starts a thread that populates the subprocess's standard input.
-    # Otherwise we risk a deadlock - there is no output because the process is waiting
-    # for more input.
+    # This context starts a thread that populates the subprocess's standard input. It
+    # also starts a threads that reads the proceses standard error. Otherwise we risk
+    # a deadlock - there is no output because the process is waiting for more input.
     #
     # This itself introduces its own complications and risks, but hopefully mitigated
-    # by having a well defined entry and exit mechanism that avoids sending data
+    # by having a well defined start and stop mechanism that also avoid sending data
     # to the process if it's not running
     #
+    # To start, i.e. on entry to the context from client code
     # - The process is started
-    # - The thread is started
-    # - The thread iterates over the input, passing the input chunks to the process
-    # - The thread is instructed to stop iterating and close the process's standard input
-    # - Wait for the thread to exit
+    # - The thread to read from standard error is started
+    # - The thread to populate input is started
+    #
+    # When running:
+    # - The standard input thread iterates over the input, passing chunks to the process
+    # - While the standard error thread fetches the error output
+    # - And while this thread iterates over the processe's output from client code
+    #   in the context
+    #
+    # To stop, i.e. on exit of the context from client code
+    # - The standard input thread is instructed to stop iterating and close the
+    #   process's standard input
+    # - This thread reads any residual standard output and discards it
+    # - Wait for the standard input thread to exit
+    # - Wait for the standard error thread to exit
     # - Wait for the process to exit
     #
-    # By using context manager internally, this also gives quite strong guarentees that
+    # By using context managers internally, this also gives quite strong guarentees that
     # the above order is enforced to make sure the thread doesn't send data to the process
     # whose standard input is closed and so we don't get BrokenPipe errors
 

--- a/iterable_subprocess.py
+++ b/iterable_subprocess.py
@@ -76,8 +76,8 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
 
     with \
             Popen(program, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc, \
-            thread(input_to, proc.stdin, lambda: exiting), \
-            thread(keep_only_most_recent, proc.stderr, stderr_deque):
+            thread(keep_only_most_recent, proc.stderr, stderr_deque), \
+            thread(input_to, proc.stdin, lambda: exiting):
 
         output = output_from(proc.stdout)
 


### PR DESCRIPTION
This probably doesn't make much of a difference, but it's nicer to have the "output" thread/processes together when making the contexts.